### PR TITLE
added support for exclude-file-regex & include-file-regex, add support "CUSTOM_TRACKER_URL" as a single url or a list of urls separated by comma(,), and parse result to aria2 format to allow for example:

### DIFF
--- a/aria2.conf
+++ b/aria2.conf
@@ -95,7 +95,7 @@ max-concurrent-downloads=5
 
 # 单服务器最大连接线程数, 任务添加时可指定, 默认:1
 # 最大值为 16 (增强版无限制), 且受限于单任务最大连接线程数(split)所设定的值。
-max-connection-per-server=16
+max-connection-per-server=32
 
 # 单任务最大连接线程数, 任务添加时可指定, 默认:5
 split=64
@@ -201,18 +201,18 @@ bt-max-peers=128
 # BT 下载期望速度值（单任务），运行时可修改。单位 K 或 M 。默认:50K
 # BT 下载速度低于此选项值时会临时提高连接数来获得更快的下载速度，不过前提是有更多的做种者可供连接。
 # 实测临时提高连接数没有上限，但不会像不做限制一样无限增加，会根据算法进行合理的动态调节。
-bt-request-peer-speed-limit=10M
+bt-request-peer-speed-limit=20M
 
 # 全局最大上传速度限制, 运行时可修改, 默认:0 (无限制)
 # 设置过低可能影响 BT 下载速度
-max-overall-upload-limit=2M
+max-overall-upload-limit=4M
 
 # 单任务上传速度限制, 默认:0 (无限制)
 max-upload-limit=0
 
 # 最小分享率。当种子的分享率达到此选项设置的值时停止做种, 0 为一直做种, 默认:1.0
 # 强烈建议您将此选项设置为大于等于 1.0
-seed-ratio=1.0
+seed-ratio=2.0
 
 # 最小做种时间（分钟）。设置为 0 时将在 BT 任务下载完成后停止做种。
 seed-time=0
@@ -225,7 +225,7 @@ bt-seed-unverified=false
 
 # BT tracker 服务器连接超时时间（秒）。默认：60
 # 建立连接后，此选项无效，将使用 bt-tracker-timeout 选项的值
-bt-tracker-connect-timeout=10
+bt-tracker-connect-timeout=15
 
 # BT tracker 服务器超时时间（秒）。默认：60
 bt-tracker-timeout=10
@@ -234,7 +234,7 @@ bt-tracker-timeout=10
 #bt-tracker-interval=0
 
 # BT 下载优先下载文件开头或结尾
-bt-prioritize-piece=head=32M,tail=32M
+bt-prioritize-piece=head=128M,tail=32M
 
 # 保存通过 WebUI(RPC) 上传的种子文件(.torrent)，默认:true
 # 所有涉及种子文件保存的选项都建议开启，不保存种子文件有任务丢失的风险。

--- a/core
+++ b/core
@@ -68,6 +68,8 @@ LOAD_SCRIPT_CONF() {
     MIN_SIZE="$(grep ^min-size "${SCRIPT_CONF}" | cut -d= -f2-)"
     INCLUDE_FILE="$(grep ^include-file "${SCRIPT_CONF}" | cut -d= -f2-)"
     EXCLUDE_FILE="$(grep ^exclude-file "${SCRIPT_CONF}" | cut -d= -f2-)"
+    INCLUDE_FILE_REGEX="$(grep ^include-file-regex "${SCRIPT_CONF}" | cut -d= -f2-)"
+    EXCLUDE_FILE_REGEX="$(grep ^exclude-file-regex "${SCRIPT_CONF}" | cut -d= -f2-)"
 }
 
 READ_ARIA2_CONF() {
@@ -213,11 +215,13 @@ DELETE_EMPTY_DIR() {
 }
 
 DELETE_EXCLUDE_FILE() {
-    if [[ ${FILE_NUM} -gt 1 ]] && [[ -n ${MIN_SIZE} || -n ${INCLUDE_FILE} || -n ${EXCLUDE_FILE} ]]; then
+    if [[ ${FILE_NUM} -gt 1 ]] && [[ -n ${MIN_SIZE} || -n ${INCLUDE_FILE} || -n ${EXCLUDE_FILE} ]] || -n ${EXCLUDE_FILE_REGEX} ]] || -n ${INCLUDE_FILE_REGEX} ]]; then
         echo -e "${INFO} Deleting excluded files ..."
         [[ -n ${MIN_SIZE} ]] && find "${TASK_PATH}" -type f -size -${MIN_SIZE} -print0 | xargs -0 rm -vf
         [[ -n ${EXCLUDE_FILE} ]] && find "${TASK_PATH}" -type f -regextype posix-extended -iregex ".*\.(${EXCLUDE_FILE})" -print0 | xargs -0 rm -vf
         [[ -n ${INCLUDE_FILE} ]] && find "${TASK_PATH}" -type f -regextype posix-extended ! -iregex ".*\.(${INCLUDE_FILE})" -print0 | xargs -0 rm -vf
+        [[ -n ${EXCLUDE_FILE_REGEX} ]] && find "${TASK_PATH}" -type f -regextype posix-extended -iregex "${EXCLUDE_FILE_REGEX}" -print0 | xargs -0 rm -vf
+        [[ -n ${INCLUDE_FILE_REGEX} ]] && find "${TASK_PATH}" -type f -regextype posix-extended ! -iregex "${INCLUDE_FILE_REGEX}" -print0 | xargs -0 rm -vf
     fi
 }
 

--- a/script.conf
+++ b/script.conf
@@ -72,3 +72,11 @@ delete-empty-dir=true
 
 # 排除文件类型。排除的文件类型将在下载完成后被删除。
 #exclude-file=html|url|lnk|txt|jpg|png
+
+
+# 保留文件类型。其它文件类型将在下载完成后被删除。
+#include-file-regex=
+
+# 排除文件类型。排除的文件类型将在下载完成后被删除。
+#exclude-file-regex=_+padding_+file.*_+
+

--- a/tracker.sh
+++ b/tracker.sh
@@ -26,22 +26,30 @@ INFO="[${GREEN_FONT_PREFIX}INFO${FONT_COLOR_SUFFIX}]"
 ERROR="[${RED_FONT_PREFIX}ERROR${FONT_COLOR_SUFFIX}]"
 ARIA2_CONF=${1:-aria2.conf}
 DOWNLOADER="curl -fsSL --connect-timeout 3 --max-time 3 --retry 2"
+NL=$'\n'
 
 DATE_TIME() {
     date +"%m/%d %H:%M:%S"
 }
 
 GET_TRACKERS() {
-    echo && echo -e "$(DATE_TIME) ${INFO} Get BT trackers ..."
+    
     if [[ -z "${CUSTOM_TRACKER_URL}" ]]; then
+        echo && echo -e "$(DATE_TIME) ${INFO} Get BT trackers..."
         TRACKER=$(
             ${DOWNLOADER} https://trackerslist.com/all_aria2.txt ||
                 ${DOWNLOADER} https://cdn.jsdelivr.net/gh/XIU2/TrackersListCollection@master/all_aria2.txt ||
                 ${DOWNLOADER} https://trackers.p3terx.com/all_aria2.txt
         )
     else
-        TRACKER=$(${DOWNLOADER} ${CUSTOM_TRACKER_URL} | awk NF | sed ":a;N;s/\n/,/g;ta")
+        echo && echo -e "$(DATE_TIME) ${INFO} Get BT trackers from url(s):${CUSTOM_TRACKER_URL} ..."
+        URLS=$(echo ${CUSTOM_TRACKER_URL} | tr "," "$NL")
+        for URL in $URLS; do
+            TRACKER+="$(${DOWNLOADER} ${URL} | tr "," "\n")$NL"
+        done
+        TRACKER="$(echo "$TRACKER" | awk NF | sort -u | sed 'H;1h;$!d;x;y/\n/,/' )"
     fi
+
     [[ -z "${TRACKER}" ]] && {
         echo
         echo -e "$(DATE_TIME) ${ERROR} Unable to get trackers, network failure or invalid links." && exit 1


### PR DESCRIPTION

added support for exclude-file-regex & include-file-regex #53  

support "CUSTOM_TRACKER_URL" as a single url or a list of urls separated by comma(,), and parse result to aria2 format
to allow for example:
```
CUSTOM_TRACKER_URL=https://trackerslist.com/all_aria2.txt,https://ngosang.github.io/trackerslist/trackers_all.txt,https://trackerslist.com/all.txt
```
