### PR TITLE
Replaced Url

### DIFF
--- a/tracker.sh
+++ b/tracker.sh
@@ -50,7 +50,7 @@ GET_TRACKERS() {
         echo && echo -e "$(DATE_TIME) ${INFO} Get BT trackers..."
         TRACKER=$(
             ${DOWNLOADER} https://trackerslist.com/all_aria2.txt ||
-                ${DOWNLOADER} https://cdn.staticaly.com/gh/XIU2/TrackersListCollection@master/all_aria2.txt ||
+                ${DOWNLOADER} https://cdn.statically.io/gh/XIU2/TrackersListCollection/master/all_aria2.txt ||
                 ${DOWNLOADER} https://trackers.p3terx.com/all_aria2.txt
         )
     else


### PR DESCRIPTION
The original CDN address is no longer accessible, update to the latest referring to [statically](https://statically.io/).